### PR TITLE
Enable interaction with USB devices within the container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,5 @@ services:
         - ./volumes/data:/home/fermentrack/fermentrack/data
         - ./volumes/log:/home/fermentrack/fermentrack/log
         - ./volumes/db:/home/fermentrack/fermentrack/db
+        - /dev:/dev
+    privileged: true


### PR DESCRIPTION
I think there were only two changes that needed to be made to get this to work:

- Enables privileged mode
- Links the host `/dev/` to the container's `/dev/`