### PR TITLE
Tweak GitHub Action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,13 +7,30 @@ on:
     branches: [ master ]
 
 jobs:
-
-  build:
-
+  buildx:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+    -
+      name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+    -
+      name: Build the Docker image
       working-directory: ./fermentrack
+      run: |
+        docker buildx build \
+        --platform=linux/arm/v7,linux/amd64 \
+        --output "type=image" \
+        --file Dockerfile . \
+        --tag my-image-name:$(date +%s)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,5 @@ services:
         - ./volumes/data:/home/fermentrack/fermentrack/data
         - ./volumes/log:/home/fermentrack/fermentrack/log
         - ./volumes/db:/home/fermentrack/fermentrack/db
+        - /dev:/dev
+    privileged: true


### PR DESCRIPTION
One thing I noticed is that your GitHub action currently only test-builds for the default platform (which I am assuming is amd64). I actually was having some issues yesterday with my image, where the armv7 (which works on Raspberry Pi 2/3/4) build was failing due to an update to esptool which suddenly required the Python `cryptography` package.

Similar to your action, this revised action test-builds -- but does not push to Docker Hub -- the docker images both on push and on each submitted pull request.  