### PR TITLE
Updates to match april release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,25 @@ If you want to know more about Fermentrack please go to https://docs.fermentrack
 
 In the future the version tag will be used to track the base installation, linux version, nginx, redis python etc. There will most likley be a new build every 3-6 months to include new security fixes from the core components. But you can always fork the repository and do your own build if you want. 
 
+```
+Note! Older images are no longer compatible with Fermentrack releases after 5 April 2021. Use image v0.8 or higher
+```
+
 These are the builds that have been released so far.
 
-Newer versions have switched to debian and is now support more targets i386/amd64/armv7
+Newer versions have switched to debian and is now support more targets i386/amd64/arm64
 
-- v0.8.0 = Updated to work with fermentrack release from 5 Apr 2021. New path to static django files and path to requirements.txt
- 
+### v0.8.0 Updated to work with fermentrack release from 5 Apr 2021. 
+- New path to static django files
+- New file for python requirements
+- Running in docker mode now uses /app for launching background tasks
+
+### v0.7.0
+- added script for debugging tilt connections 
+- healthcheck for nginx/redis/django
+
 These versions only exist for amd64 target and are based on ubuntu stable release
 
-- v0.7.0 = added script for debugging tilt connections + healthcheck for nginx/redis/django
 - v0.6.0 = fermentrack release b4e7378 from 19 Dec 2020, tested bluetooth and firmware update
 - v0.5.0 = fermentrack release b4e7378 from 19 Dec 2020, tested bluetooth and firmware update
 - v0.4.0 = fermentrack release 3f6a8a1 from 11 Nov 2020, locked version of numpy since the latest version gave wrong result in gravity calculation

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -16,7 +16,7 @@ A configuration file for docker compose is included in the repository and the ea
 But if you want to build for other architectures you can use buildx for that:
 
 ``docker buildx build ./fermentrack --platform linux/amd64``
-``docker buildx build ./fermentrack --platform linux/arm/v7``
+``docker buildx build ./fermentrack --platform linux/arm64``
 
 This is a good guide for using buildx with docker and arm.
 

--- a/fermentrack/Dockerfile
+++ b/fermentrack/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libcap2-bin \
   curl \
 # For debugging
+# procps
+# net-tools
   nano \
   usbutils
 #
@@ -54,6 +56,8 @@ RUN git clone https://github.com/thorrak/fermentrack.git /home/fermentrack/ferme
 #
 USER root
 WORKDIR /home/fermentrack
+# With the introduction of docker it uses /app for launching processes
+RUN ln -s /home/fermentrack/fermentrack /app
 RUN pip3 install --upgrade pip
 RUN pip3 install virtualenv
 RUN virtualenv venv
@@ -61,9 +65,10 @@ ENV VIRTUAL_ENV="/home/fermentrack/venv"
 ENV PATH="/home/fermentrack/venv/bin:/usr/bin:/usr/sbin:/bin:/sbin"
 ENV PYTHONPATH=":;/home/fermentrack/fermentrack;/home/fermentrack/venv/bin;/home/fermentrack/venv/lib/python3.8/site-packages"
 ENV USE_DOCKER=true
+RUN pip3 install --no-binary numpy numpy==1.18.4
+RUN pip3 install --no-binary pyzmq pyzmq==19.0.1
+RUN pip3 install circus
 RUN pip3 install --no-cache-dir -r /home/fermentrack/fermentrack/requirements/base.txt
-#RUN pip3 install --no-cache-dir -r /home/fermentrack/fermentrack/requirements/docker-production.txt
-RUN pip3 install numpy==1.18.4
 RUN chown -R fermentrack:fermentrack /home/fermentrack/venv
 #
 # Setup nginx and update config to point towards fermentrack. 

--- a/fermentrack/entrypoint.sh
+++ b/fermentrack/entrypoint.sh
@@ -101,5 +101,6 @@ git log -n 1 --pretty=short
 echo "****************************************************************"
 
 echo "Starting circus deamon"
-circusd circus.ini
+#circusd --log-level DEBUG circus-docker.ini
+circusd circus-docker.ini
 EOF


### PR DESCRIPTION
Added link to /app (which is the default dir when running under docker (new behavious)
Using circus docker settings
New path to python packages.
Changes in pyhton installation steps
Note! Older docker images are no longer compatible with fermentrack releases after april 5 2021